### PR TITLE
Added hook-deps to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# repos
+project-service
+auth-service
+eureka-service
+config-service
+zuul-service
+
+/.metadata/
+
 # Compiled class file
 *.class 
 
@@ -95,9 +104,14 @@ hibernate.cfg.xml
 # sonarlint modules
 .sonarlint
 
-# target folder
-target/
-
 # config files (bootstrap.yml will stay on repo, but no need to update it)
 bootstrap.yml
 application.yml
+
+# Target Directory
+target/
+
+.vscode/
+
+# hook-deps
+.hook-deps/


### PR DESCRIPTION
Modified .gitignore to include `hook-deps` folder. This is when I realized I made a mistake on the other gitignore files and corrected them. This one includes some additional ignores not found in the original as well such as the other repos and the target folder. These are a consequence of copying the gitignore form other repos in the MSA. It should have no ill effects.